### PR TITLE
CLI improvements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,23 +44,24 @@ some output and results to obtain.
 
 ```
 Usage:
-  * cloud_test [flags]
-  * cloud_test [command]
+  cloudtest [flags]
+  cloudtest [command]
 
 Available Commands:
   help        Help about any command
-  version     Print the version number of cloud_test
+  version     Print the version number of cloudtest
 
 Flags:
-  -c, --clusters stringArray   Enable disable cluster configs, default use from config. Cloud be used to test against selected configuration or locally...
-      --config string          Config file for providers, default=.cloudtest.yaml
-      --count int              Execute only count of tests (default -1)
-  -e, --enabled                Use only passed cluster names...
-  -h, --help                   help for cloud_test
-      --noInstall              Pass to disable do install operations...
-      --noMask                 Pass to disable masking of environment variables...
-      --noPrepare              Pass to disable do prepare operations...
-      --noStop                 Pass to disable stop operations...
+  -c, --cluster strings   Enable only specified cluster config(s)
+      --config string     Config file, default=.cloudtest.yaml
+      --count int         Execute only count of tests (default -1)
+  -h, --help              help for cloudtest
+  -k, --kind strings      Enable only specified cluster kind(s)
+      --noInstall         Skip install operations
+      --noMask            Disable masking of environment variables in output
+      --noPrepare         Skip prepare operations
+      --noStop            Skip stop operations
+  -t, --tags strings      Run tests with given tag(s) only
 ```
 
 ### Configuration file

--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -61,6 +61,7 @@ type Arguments struct {
 	providerConfig  string   // A folder to start scaning for tests inside
 	count           int      // Limit number of tests to be run per every cloud
 	instanceOptions providers.InstanceOptions
+	onlyRun         []string // A list of tests to run.
 }
 
 type clusterState byte
@@ -171,6 +172,10 @@ func CloudTestRun(cmd *cloudTestCmd) {
 	if err != nil {
 		logrus.Errorf("Failed to parse config %v", err)
 		os.Exit(1)
+	}
+
+	if len(cmd.cmdArguments.onlyRun) > 0 {
+		testConfig.OnlyRun = cmd.cmdArguments.onlyRun
 	}
 
 	if len(testConfig.OnlyRun) > 0 {
@@ -1387,17 +1392,12 @@ func (ctx *executionContext) findGoTest(executionConfig *config.Execution) ([]*m
 	for _, t := range execTests {
 		t.Kind = model.TestEntryKindGoTest
 		t.ExecutionConfig = executionConfig
-		match := true
-		for _, v := range executionConfig.OnlyRun {
-			match = false
-			if v == t.Name {
-				match = true
-				break
-			}
-		}
-		if match {
+		if len(executionConfig.OnlyRun) == 0 || utils.Contains(executionConfig.OnlyRun, t.Name) {
 			result = append(result, t)
 		}
+	}
+	if len(result) != len(execTests) {
+		logrus.Infof("Tests after filtering: %v", len(result))
 	}
 	return result, nil
 }
@@ -1756,6 +1756,7 @@ func ExecuteCloudTest() {
 	rootCmd.Short = "NSM Cloud Test is cloud helper continuous integration testing tool"
 	rootCmd.Long = `Allow to execute all set of individual tests across all clouds provided.`
 	rootCmd.Run = func(cmd *cobra.Command, args []string) {
+		rootCmd.cmdArguments.onlyRun = args
 		CloudTestRun(rootCmd)
 	}
 	rootCmd.Args = func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Cisco Systems, Inc and/or its affiliates.
+// Copyright (c) 2019-2020 Cisco Systems, Inc and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -172,6 +172,16 @@ func CloudTestRun(cmd *cloudTestCmd) {
 		os.Exit(1)
 	}
 
+	if len(testConfig.OnlyRun) > 0 {
+		logrus.Infof("Imposing top-level 'only-run' tests to all executions: %v", testConfig.OnlyRun)
+		for _, e := range testConfig.Executions {
+			if len(e.OnlyRun) > 0 {
+				logrus.Warningf("Overwriting non-empty 'only-run' on execution '%s'", e.Name)
+			}
+			e.OnlyRun = testConfig.OnlyRun
+		}
+	}
+
 	// Process config imports
 	err = performImport(testConfig)
 	if err != nil {

--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -59,7 +59,6 @@ type Arguments struct {
 	providerConfig  string   // A folder to start scaning for tests inside
 	count           int      // Limit number of tests to be run per every cloud
 	instanceOptions providers.InstanceOptions
-	onlyEnabled     bool // Disable all clusters and enable only enabled in command line.
 }
 
 type clusterState byte
@@ -1237,23 +1236,11 @@ func (ctx *executionContext) createClusters() error {
 	}
 
 	for _, cl := range ctx.cloudTestConfig.Providers {
-		if ctx.arguments.onlyEnabled {
-			logrus.Infof("Disable cluster config:: %v since onlyEnabled is passed...", cl.Name)
-			cl.Enabled = false
-		}
-		for _, cc := range ctx.arguments.clusters {
-			if cl.Name == cc {
-				if !cl.Enabled {
-					logrus.Infof("Enabling config:: %v", cl.Name)
-				}
-				cl.Enabled = true
-			}
-		}
-		if cl.Enabled {
-			logrus.Infof("Initialize provider for config:: %v %v", cl.Name, cl.Kind)
+		if enable, testCount := ctx.shouldEnableCluster(cl); enable {
+			logrus.Infof("Initialize provider for config: %v %v", cl.Name, cl.Kind)
 			provider, ok := clusterProviders[cl.Kind]
 			if !ok {
-				msg := fmt.Sprintf("Cluster provider %s are not found...", cl.Kind)
+				msg := fmt.Sprintf("Cluster provider '%s' not found", cl.Kind)
 				logrus.Errorf(msg)
 				return errors.New(msg)
 			}
@@ -1313,6 +1300,22 @@ func (ctx *executionContext) appendTests(tests ...*model.TestEntry) {
 		rand.Shuffle(len(tests), func(i, j int) { tests[i], tests[j] = tests[j], tests[i] })
 	}
 	ctx.tests = append(ctx.tests, tests...)
+}
+
+func (ctx *executionContext) shouldEnableCluster(cl *config.ClusterProviderConfig) (bool, int) {
+	enabledByCommandLine := utils.Contains(ctx.arguments.clusters, cl.Name)
+	if !cl.Enabled && !enabledByCommandLine {
+		logrus.Infof("Skipping disabled cluster config: %v", cl.Name)
+		return false, 0
+	}
+	cl.Enabled = len(ctx.arguments.clusters) == 0 || enabledByCommandLine
+	if !cl.Enabled {
+		logrus.Infof("Disabling cluster config by cluster filter: %v", cl.Name)
+		return false, 0
+	}
+	testCount := 0
+
+	return cl.Enabled, testCount
 }
 
 func (ctx *executionContext) findTests() error {
@@ -1734,7 +1737,7 @@ func ExecuteCloudTest() {
 			clusters:       []string{},
 		},
 	}
-	rootCmd.Use = "cloud_test"
+	rootCmd.Use = "cloudtest"
 	rootCmd.Short = "NSM Cloud Test is cloud helper continuous integration testing tool"
 	rootCmd.Long = `Allow to execute all set of individual tests across all clouds provided.`
 	rootCmd.Run = func(cmd *cobra.Command, args []string) {
@@ -1754,19 +1757,25 @@ func ExecuteCloudTest() {
 
 func initCmd(rootCmd *cloudTestCmd) {
 	cobra.OnInitialize(initConfig)
-	rootCmd.Flags().StringVarP(&rootCmd.cmdArguments.providerConfig, "config", "", "", "Config file for providers, default="+defaultConfigFile)
-	rootCmd.Flags().StringArrayVarP(&rootCmd.cmdArguments.clusters, "clusters", "c", []string{}, "Enable disable cluster configs, default use from config. Cloud be used to test against selected configuration or locally...")
-	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.onlyEnabled, "enabled", "e", false, "Use only passed cluster names...")
-	rootCmd.Flags().IntVarP(&rootCmd.cmdArguments.count, "count", "", -1, "Execute only count of tests")
+	rootCmd.Flags().StringVarP(&rootCmd.cmdArguments.providerConfig,
+		"config", "", "", "Config file, default="+defaultConfigFile)
+	rootCmd.Flags().StringSliceVarP(&rootCmd.cmdArguments.clusters,
+		"cluster", "c", []string{}, "Enable only specified cluster config(s)")
+	rootCmd.Flags().IntVarP(&rootCmd.cmdArguments.count,
+		"count", "", -1, "Execute only count of tests")
 
-	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoStop, "noStop", "", false, "Pass to disable stop operations...")
-	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoInstall, "noInstall", "", false, "Pass to disable do install operations...")
-	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoPrepare, "noPrepare", "", false, "Pass to disable do prepare operations...")
-	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoMaskParameters, "noMask", "", false, "Pass to disable masking of environment variables...")
+	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoStop,
+		"noStop", "", false, "Skip stop operations")
+	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoInstall,
+		"noInstall", "", false, "Skip install operations")
+	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoPrepare,
+		"noPrepare", "", false, "Skip prepare operations")
+	rootCmd.Flags().BoolVarP(&rootCmd.cmdArguments.instanceOptions.NoMaskParameters,
+		"noMask", "", false, "Disable masking of environment variables in output")
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of cloud_test",
+		Short: "Print the version number of cloudtest",
 		Long:  `All software has versions.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Cloud Test -- HEAD")

--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -1265,6 +1266,10 @@ func (ctx *executionContext) createClusters() error {
 				tasks:     map[string]*testTask{},
 				completed: map[string]*testTask{},
 			}
+			testsPerInstance := int(math.Min(float64(ctx.cloudTestConfig.TestsPerClusterInstance), 20))
+			// initial value of cl.Instances is treated as allowed maximum
+			cl.Instances = int(math.Ceil(math.Min(float64(testCount)/float64(testsPerInstance), float64(cl.Instances))))
+			logrus.Infof("Creating %d instances of '%s' cluster to run %d test(s)", cl.Instances, cl.Name, testCount)
 			for i := 0; i < cl.Instances; i++ {
 				cluster, err := provider.CreateCluster(cl, ctx.factory, ctx.manager, ctx.arguments.instanceOptions)
 				if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,8 @@ type CloudTestConfig struct {
 		Enabled  bool  `yaml:"enabled"`  // A way to disable printing of statistics
 	} `yaml:"statistics"` // Statistics options
 
-	ShuffleTests bool `yaml:"shuffle-enabled"` // Shuffle tests before assignment
+	ShuffleTests bool     `yaml:"shuffle-enabled"` // Shuffle tests before assignment
+	OnlyRun      []string `yaml:"only-run"`        // If non-empty, only run the listed tests
 }
 
 // NewCloudTestConfig - creates a test config with some default values specified.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,6 +111,8 @@ type CloudTestConfig struct {
 
 	ShuffleTests bool     `yaml:"shuffle-enabled"` // Shuffle tests before assignment
 	OnlyRun      []string `yaml:"only-run"`        // If non-empty, only run the listed tests
+
+	TestsPerClusterInstance int `yaml:"tests-per-cluster-instance"` // Number of tests per cluster instance
 }
 
 // NewCloudTestConfig - creates a test config with some default values specified.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Cisco Systems, Inc and/or its affiliates.
+// Copyright (c) 2019-2020 Cisco Systems, Inc and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,7 @@ type Execution struct {
 	OnFail          string          `yaml:"on_fail"`          // A script to execute against required cluster, called if task failed
 
 	ConcurrencyRetry int64 `yaml:"test-retry-count"` // A count of times, same test will be executed to find concurrency issues
+	TestsFound       int   `yaml:"-"`                // Number of tests found for the config
 }
 
 type RetestConfig struct {


### PR DESCRIPTION
- global option for cloudtest utility to run only tests that specified, in order of priority:
  -- by name(s) as positional command line parameters
  -- only-run filed of cloudtest config 

- automatic number of clusters instances: the number of instances for each provider is calculated using 'tests-per-cluster-instance' parameter in config and number of tests involving the provider. providers.instances field is now interpreted as maximum allowed number of instances to start.

- 'kind' and 'tags' options to select tests based on provider's kind and test's tags