### PR TITLE
Fix: Path to test artifacts directory is not absolute

### DIFF
--- a/pkg/execmanager/manager.go
+++ b/pkg/execmanager/manager.go
@@ -98,6 +98,7 @@ func (mgr *executionManagerImpl) OpenFileTest(category, testName, operation stri
 func (mgr *executionManagerImpl) AddFolder(category, name string) string {
 	result := path.Join(mgr.root, category, name)
 	_ = os.MkdirAll(result, os.ModePerm)
+	result, _ = filepath.Abs(result)
 	return result
 }
 


### PR DESCRIPTION
if the root of cloudtest config has a relative path then the test could not find the artifacts directory.