### PR TITLE
Fix: clusters instance starts in 2 threads

### DIFF
--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -1128,6 +1128,9 @@ func (ctx *executionContext) startCluster(ci *clusterInstance) bool {
 			execution.logFile = errFile
 			execution.errMsg = err
 			execution.status = clusterCrashed
+			ctx.Lock()
+			ci.state = clusterStopping
+			ctx.Unlock()
 			destroyErr := ctx.destroyCluster(ci, true, false)
 			if destroyErr != nil {
 				logrus.Errorf("Both start and destroy of cluster returned errors, stop retrying operations with this cluster %v", ci.instance)

--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -1200,7 +1200,7 @@ func (ctx *executionContext) monitorCluster(context context.Context, ci *cluster
 }
 
 func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, fork bool) error {
-	if ci.state == clusterCrashed || ci.state == clusterNotAvailable || ci.state == clusterShutdown {
+	if ci.state == clusterCrashed || ci.state == clusterNotAvailable || ci.state == clusterShutdown || ci.state == clusterStarting {
 		// It is already destroyed or not available.
 		return nil
 	}


### PR DESCRIPTION
Issue #17 

Signed-off-by: Artem Belov <artem.belov@xored.com>

Log from https://circleci.com/gh/networkservicemesh/networkservicemesh/120648
Cluster instance starts in two threads in parallel. Test 1 starts when thread 1 finished. Thread 2 change instance state to "ready" when finished
```
ERRO[1527] Failed to interact with azure-1: Cluster doesn't have required number of nodes to be available. Required: 2 Available: 1 
INFO[1527] Destroying cluster  azure-1                  
INFO[1527] destroy-0: azure-1 => make azure-destroy     
INFO[1533] Cluster instance azure-1 is updated: state: crashed 
INFO[1533] Starting cluster azure-azure-1               
INFO[1533] Cleaning report folder /home/circleci/project/.tests/cloud_test/shell/azure-1 
INFO[1533] start: azure-1 => make azure-start           
INFO[1533] TestNSMHealRemoteDieNSMD_NSE: OnFail: running on fail script operations with KUBECONFIG=/home/circleci/project/.tests/cloud_test/shell/azure-1/config on cloud azure-1 
ERRO[1534] Task failed because cluster is not valid: TestNSMHealRemoteDieNSMD_NSE azure-1 Cluster doesn't have required number of nodes to be available. Required: 2 Available: 1 
INFO[1534] Destroying cluster  azure-1                  
INFO[1534] destroy-0: azure-1 => make azure-destroy     
INFO[1536] Cluster instance azure-1 is updated: state: crashed 
INFO[1536] Cluster instance azure-1 is updated: state: starting 
INFO[1536] Starting cluster azure-azure-1               
INFO[1536] Cleaning report folder /home/circleci/project/.tests/cloud_test/shell/azure-1 
INFO[1536] start: azure-1 => make azure-start    
```