### PR TITLE
fix: handleScript writes warning for an empty script to main log

### DIFF
--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -1704,7 +1704,7 @@ func (ctx *executionContext) isClusterDown(inst *clusterInstance) bool {
 
 func (ctx *executionContext) handleScript(args *runScriptArgs) error {
 	if strings.TrimSpace(args.Script) == "" {
-		logrus.Warnf("%v is empty script. Nothing to run", args.Name)
+		_, _ = args.Out.WriteString(fmt.Sprintf("%v is empty script. Nothing to run\n", args.Name))
 		return nil
 	}
 	mgr := shell_mgr.NewEnvironmentManager()


### PR DESCRIPTION
The subj causes lot of unnecessary warning about empty After/Before script in log:

WARN[1253] After is empty script. Nothing to run        
WARN[1253] After is empty script. Nothing to run        
WARN[1253] Before is empty script. Nothing to run       
WARN[1253] Before is empty script. Nothing to run       
WARN[1253] After is empty script. Nothing to run        