### PR TITLE
Add missed newline separator for logs of failed tests

### DIFF
--- a/pkg/commands/execution_context.go
+++ b/pkg/commands/execution_context.go
@@ -1621,7 +1621,7 @@ func (ctx *executionContext) generateTestCaseReport(test *testTask, totalTests i
 				logrus.Errorf("Failed to read stored output %v", ex.OutputFile)
 				lines = []string{"Failed to read stored output:", ex.OutputFile, err.Error()}
 			}
-			result.WriteString(fmt.Sprintf("Execution attempt: %v Output file: %v", idx, ex.OutputFile))
+			result.WriteString(fmt.Sprintf("Execution attempt: %v Output file: %v\n", idx, ex.OutputFile))
 			result.WriteString(strings.Join(lines, "\n"))
 		}
 		testCase.Failure = &reporting.Failure{


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

Fixes this:
```
Execution attempt: 0 Output file: .tests/cloud_test/gke-6/031-TestNSEHealRemoteVpp-run.logStarting TestNSEHealRemoteVpp on gke-6
```
To this:
```
Execution attempt: 0 Output file: .tests/cloud_test/gke-6/031-TestNSEHealRemoteVpp-run.log
Starting TestNSEHealRemoteVpp on gke-6
```