### PR TITLE
Fix invalid k8s.io/client-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	k8s.io/api v0.18.1
 	k8s.io/apimachinery v0.18.1
-	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/client-go v0.18.1
 )
 
 replace (


### PR DESCRIPTION
`k8s.io/client-go` version has been updated in `replace` block, but not in `require` block. 